### PR TITLE
87 double quoted filename

### DIFF
--- a/demo/demoproject/fixtures/hello-world.txt
+++ b/demo/demoproject/fixtures/hello-world.txt
@@ -1,1 +1,1 @@
-Hellow world!
+Hello world!

--- a/demo/demoproject/fixtures/hello-world.txt
+++ b/demo/demoproject/fixtures/hello-world.txt
@@ -1,1 +1,1 @@
-Hello world!
+Hellow world!

--- a/demo/demoproject/http/views.py
+++ b/demo/demoproject/http/views.py
@@ -4,7 +4,7 @@ from django_downloadview import HTTPDownloadView
 class SimpleURLDownloadView(HTTPDownloadView):
     def get_url(self):
         """Return URL of hello-world.txt file on GitHub."""
-        return 'https://raw.github.com/benoitbryon/django-downloadview' \
+        return 'https://raw.githubusercontent.com/benoitbryon/django-downloadview' \
                '/b7f660c5e3f37d918b106b02c5af7a887acc0111' \
                '/demo/demoproject/download/fixtures/hello-world.txt'
 

--- a/django_downloadview/response.py
+++ b/django_downloadview/response.py
@@ -58,7 +58,7 @@ def content_disposition(filename):
     u"""Return value of ``Content-Disposition`` header with 'attachment'.
 
     >>> print(content_disposition('demo.txt'))
-    attachment; filename=demo.txt
+    attachment; filename="demo.txt"
 
     If filename is empty, only "attachment" is returned.
 

--- a/django_downloadview/response.py
+++ b/django_downloadview/response.py
@@ -77,9 +77,9 @@ def content_disposition(filename):
     ascii_filename = encode_basename_ascii(filename)
     utf8_filename = encode_basename_utf8(filename)
     if ascii_filename == utf8_filename:  # ASCII only.
-        return "attachment; filename={ascii}".format(ascii=ascii_filename)
+        return "attachment; filename=\"{ascii}\"".format(ascii=ascii_filename)
     else:
-        return "attachment; filename={ascii}; filename*=UTF-8''{utf8}" \
+        return "attachment; filename=\"{ascii}\"; filename*=UTF-8''\"{utf8}\"" \
                .format(ascii=ascii_filename,
                        utf8=utf8_filename)
 

--- a/django_downloadview/response.py
+++ b/django_downloadview/response.py
@@ -79,7 +79,7 @@ def content_disposition(filename):
     if ascii_filename == utf8_filename:  # ASCII only.
         return "attachment; filename=\"{ascii}\"".format(ascii=ascii_filename)
     else:
-        return "attachment; filename=\"{ascii}\"; filename*=UTF-8''\"{utf8}\"" \
+        return "attachment; filename=\"{ascii}\"; filename*=UTF-8''{utf8}" \
                .format(ascii=ascii_filename,
                        utf8=utf8_filename)
 

--- a/django_downloadview/response.py
+++ b/django_downloadview/response.py
@@ -69,7 +69,7 @@ def content_disposition(filename):
     UTF-8 encoded filename and US-ASCII fallback.
 
     >>> print(content_disposition(u'é.txt'))
-    attachment; filename=e.txt; filename*=UTF-8''%C3%A9.txt
+    attachment; filename="e.txt"; filename*=UTF-8''%C3%A9.txt
 
     """
     if not filename:

--- a/django_downloadview/test.py
+++ b/django_downloadview/test.py
@@ -124,7 +124,7 @@ class DownloadResponseValidator(object):
             if "filename=" in response['Content-Disposition']:
                 check_ascii = True
         if check_ascii:
-            test_case.assertIn('filename={name}'.format(
+            test_case.assertIn('filename="{name}"'.format(
                 name=ascii_name),
                 response['Content-Disposition'])
         if check_utf8:

--- a/django_downloadview/tests/response.py
+++ b/django_downloadview/tests/response.py
@@ -13,7 +13,7 @@ class DownloadResponseTestCase(unittest.TestCase):
                                     attachment=True,
                                     basename=u'espacé .txt',)
         headers = response.default_headers
-        self.assertIn("filename=espace_.txt",
+        self.assertIn("filename=\"espace_.txt\"",
                       headers['Content-Disposition'])
-        self.assertIn("filename*=UTF-8''espac%C3%A9%20.txt",
+        self.assertIn("filename*=UTF-8''\"espac%C3%A9%20.txt\"",
                       headers['Content-Disposition'])

--- a/django_downloadview/tests/response.py
+++ b/django_downloadview/tests/response.py
@@ -15,5 +15,5 @@ class DownloadResponseTestCase(unittest.TestCase):
         headers = response.default_headers
         self.assertIn("filename=\"espace_.txt\"",
                       headers['Content-Disposition'])
-        self.assertIn("filename*=UTF-8''\"espac%C3%A9%20.txt\"",
+        self.assertIn("filename*=UTF-8''espac%C3%A9%20.txt",
                       headers['Content-Disposition'])


### PR DESCRIPTION
For issue #87.  Test ASCII and UTF-8 files with and without commas.  Works in Chrome, Safari, Firefox on OS X. 