### PR TITLE
Avoid calling PathDownloadView.get_path() twice inside get_file()

### DIFF
--- a/django_downloadview/views/path.py
+++ b/django_downloadview/views/path.py
@@ -36,4 +36,4 @@ class PathDownloadView(BaseDownloadView):
         filename = self.get_path()
         if not os.path.isfile(filename):
             raise FileNotFound('File "{0}" does not exists'.format(filename))
-        return File(open(self.get_path(), 'rb'))
+        return File(open(filename, 'rb'))

--- a/tests/views.py
+++ b/tests/views.py
@@ -75,7 +75,7 @@ class DownloadMixinTestCase(unittest.TestCase):
         self.assertIs(
             mixin.was_modified_since(file_wrapper, mock.sentinel.since),
             mock.sentinel.was_modified)
-        file_wrapper.was_modified_since.assertCalledOnceWith(
+        file_wrapper.was_modified_since.assert_called_once_with(
             mock.sentinel.since)
 
     def test_was_modified_since_django(self):
@@ -101,9 +101,10 @@ class DownloadMixinTestCase(unittest.TestCase):
             self.assertIs(
                 mixin.was_modified_since(file_wrapper, mock.sentinel.since),
                 mock.sentinel.was_modified)
-        was_modified_since_mock.assertCalledOnceWith(
-            mock.sentinel.size,
-            mock.sentinel.modified_time)
+        was_modified_since_mock.assert_called_once_with(
+            mock.sentinel.since,
+            mock.sentinel.modified_time,
+            mock.sentinel.size)
 
     def test_was_modified_since_fallback(self):
         """DownloadMixin.was_modified_since() fallbacks to `True`.


### PR DESCRIPTION
Overridden PathDownloadView.get_path() may contain database lookups and logging which should not be called twice if not necessary, as it was in my case.
Because the acquired filename does not change inside get_file(), I replaced the duplicate call.