### PR TITLE
Refs #104 - Convert datetime to unix timestamp

### DIFF
--- a/django_downloadview/views/base.py
+++ b/django_downloadview/views/base.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Base material for download views: :class:`DownloadMixin` and
 :class:`BaseDownloadView`"""
+import calendar
+
 from django.http import HttpResponseNotModified, Http404
 from django.views.generic.base import View
 from django.views.static import was_modified_since
@@ -111,7 +113,8 @@ class DownloadMixin(object):
             return file_instance.was_modified_since(since)
         except (AttributeError, NotImplementedError):
             try:
-                modification_time = file_instance.modified_time
+                modification_time = calendar.timegm(
+                    file_instance.modified_time.utctimetuple())
                 size = file_instance.size
             except (AttributeError, NotImplementedError):
                 return True

--- a/tests/views.py
+++ b/tests/views.py
@@ -2,6 +2,7 @@
 """Tests around :mod:`django_downloadview.views`."""
 import os
 import unittest
+from datetime import datetime
 try:
     from unittest import mock
 except ImportError:
@@ -92,7 +93,7 @@ class DownloadMixinTestCase(unittest.TestCase):
         file_wrapper.was_modified_since = mock.Mock(
             side_effect=AttributeError)
         file_wrapper.size = mock.sentinel.size
-        file_wrapper.modified_time = mock.sentinel.modified_time
+        file_wrapper.modified_time = datetime.now()
         was_modified_since_mock = mock.Mock(
             return_value=mock.sentinel.was_modified)
         mixin = views.DownloadMixin()


### PR DESCRIPTION
Im not sure about unittests for this fix.

First i thinking about updating ``DownloadMixinTestCase.test_was_modified_since_django``: https://github.com/benoitbryon/django-downloadview/blob/master/tests/views.py#L81-L106

Just turn off mocking for ``was_modified_since``

But may be it is not good idea because we start testing around of implementation of django's  ``was_modified_since`` function

What do you think?

Sorry for closed PR. Fixed broken tests