### PR TITLE
Forward BaseDownloadView.get() args and kwargs to render_to_response()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ maintainer-clean: distclean
 .PHONY: test
 test:
 	mkdir -p var
+	$(PIP) install -U pip setuptools
 	$(PIP) install -e .[test]
 	$(TOX)
 

--- a/django_downloadview/response.py
+++ b/django_downloadview/response.py
@@ -119,7 +119,7 @@ class DownloadResponse(StreamingHttpResponse):
     """
     def __init__(self, file_instance, attachment=True, basename=None,
                  status=200, content_type=None, file_mimetype=None,
-                 file_encoding=None):
+                 file_encoding=None, **kwargs):
         """Constructor.
 
         :param content_type: Value for ``Content-Type`` header.

--- a/django_downloadview/views/base.py
+++ b/django_downloadview/views/base.py
@@ -122,8 +122,13 @@ class DownloadMixin(object):
                 return was_modified_since(since, modification_time, size)
 
     def not_modified_response(self, *response_args, **response_kwargs):
-        """Return :class:`django.http.HttpResponseNotModified` instance."""
-        return HttpResponseNotModified(*response_args, **response_kwargs)
+        """Return :class:`django.http.HttpResponseNotModified` instance.
+        Only `django.http.HttpResponseBase.__init__()` kwargs will be used."""
+        allowed_kwargs = {}
+        for k in ('content_type', 'status', 'reason', 'charset'):
+            if k in response_kwargs:
+                allowed_kwargs[k] = response_kwargs[k]
+        return HttpResponseNotModified(*response_args, **allowed_kwargs)
 
     def download_response(self, *response_args, **response_kwargs):
         """Return :class:`~django_downloadview.response.DownloadResponse`."""

--- a/django_downloadview/views/base.py
+++ b/django_downloadview/views/base.py
@@ -167,4 +167,4 @@ class BaseDownloadView(DownloadMixin, View):
     """A base :class:`DownloadMixin` that implements :meth:`get`."""
     def get(self, request, *args, **kwargs):
         """Handle GET requests: stream a file."""
-        return self.render_to_response()
+        return self.render_to_response(*args, **kwargs)

--- a/tests/views.py
+++ b/tests/views.py
@@ -221,14 +221,14 @@ class BaseDownloadViewTestCase(unittest.TestCase):
     def test_get(self):
         """BaseDownloadView.get() calls render_to_response()."""
         request = django.test.RequestFactory().get('/dummy-url')
-        args = ['dummy-arg']
-        kwargs = {'dummy': 'kwarg'}
+        args = []
+        kwargs = {'content_type': 'application/pdf'}
         view = setup_view(views.BaseDownloadView(), request, *args, **kwargs)
         view.render_to_response = mock.Mock(
             return_value=mock.sentinel.response)
         response = view.get(request, *args, **kwargs)
         self.assertIs(response, mock.sentinel.response)
-        view.render_to_response.assert_called_once_with()
+        view.render_to_response.assert_called_once_with(*args, **kwargs)
 
 
 class PathDownloadViewTestCase(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     nose
     py27: mock
 commands =
+    pip install -U pip setuptools
     pip install -e .
     pip install -e demo
     demo test --cover-package=django_downloadview --cover-package=demoproject {posargs: tests demoproject}


### PR DESCRIPTION
`BaseDownloadView.get()` should forward _args, *_kwargs to `render_to_response()` to allow overriding default values like content_type in `DownloadResponse.__init__()`.

In addition, binary mime types like **application/pdf** should not contain a charset attribute in `DownloadResponse.get_content_type()`.
Unfortunately the used mimetypes module from the standard library does not offer a text/binary differentiation, and a **text/** prefix would not be sufficient, **application/javascript** is text for example.
