### PR TITLE
Include assets in source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include django_downloadview *
 recursive-include demo *.py *.rst *.html *.json *.txt
 recursive-include docs Makefile *.py *.txt
+recursive-include tests *.py
 global-exclude *.pyc
 include AUTHORS
 include CHANGELOG

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-recursive-include django_downloadview *
 recursive-include demo *.py *.rst *.html *.json *.txt
 recursive-include docs Makefile *.py *.txt
 recursive-include tests *.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include django_downloadview *
+recursive-include demo *.py *.rst *.html *.json *.txt
 global-exclude *.pyc
 include AUTHORS
 include CHANGELOG

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 recursive-include django_downloadview *
 recursive-include demo *.py *.rst *.html *.json *.txt
+recursive-include docs Makefile *.py *.txt
 global-exclude *.pyc
 include AUTHORS
 include CHANGELOG


### PR DESCRIPTION
It would be nice to have tests and documentation sources included in the source tarball on PyPI. Also, it is not necessary to explicitly include the main Python package in MANIFEST.in as `packages=[…]` already accounts for this.

This would also be a nice addition for the Debian package that I'm working on so I can build the documentation and ship it there plus I would be able to run the tests during build to scan for regressions inside Debian.
