### PR TITLE
Pass args and kwargs around so that the get_file() method can respond to URL parameters.

### DIFF
--- a/django_downloadview/response.py
+++ b/django_downloadview/response.py
@@ -120,7 +120,7 @@ class DownloadResponse(StreamingHttpResponse):
 
     def __init__(self, file_instance, attachment=True, basename=None,
                  status=200, content_type=None, file_mimetype=None,
-                 file_encoding=None, **kwargs):
+                 file_encoding=None, extra_headers=None, **kwargs):
         """Constructor.
 
         :param content_type: Value for ``Content-Type`` header.
@@ -161,6 +161,11 @@ class DownloadResponse(StreamingHttpResponse):
         for header, value in self.default_headers.items():
             if header not in self:
                 self[header] = value  # Does self support setdefault?
+
+        # Apply any extra headers.
+        if extra_headers:
+            for header, value in extra_headers:
+                self[header] = value
 
     @property
     def default_headers(self):

--- a/django_downloadview/response.py
+++ b/django_downloadview/response.py
@@ -117,9 +117,10 @@ class DownloadResponse(StreamingHttpResponse):
       attributes (size, name, ...).
 
     """
+
     def __init__(self, file_instance, attachment=True, basename=None,
                  status=200, content_type=None, file_mimetype=None,
-                 file_encoding=None):
+                 file_encoding=None, **kwargs):
         """Constructor.
 
         :param content_type: Value for ``Content-Type`` header.

--- a/django_downloadview/response.py
+++ b/django_downloadview/response.py
@@ -120,7 +120,7 @@ class DownloadResponse(StreamingHttpResponse):
 
     def __init__(self, file_instance, attachment=True, basename=None,
                  status=200, content_type=None, file_mimetype=None,
-                 file_encoding=None, extra_headers=None, **kwargs):
+                 file_encoding=None):
         """Constructor.
 
         :param content_type: Value for ``Content-Type`` header.
@@ -161,11 +161,6 @@ class DownloadResponse(StreamingHttpResponse):
         for header, value in self.default_headers.items():
             if header not in self:
                 self[header] = value  # Does self support setdefault?
-
-        # Apply any extra headers.
-        if extra_headers:
-            for header, value in extra_headers:
-                self[header] = value
 
     @property
     def default_headers(self):

--- a/django_downloadview/views/base.py
+++ b/django_downloadview/views/base.py
@@ -60,7 +60,7 @@ class DownloadMixin(object):
     #: :mod:`mimetypes`.
     encoding = None
 
-    def get_file(self):
+    def get_file(self, *args, **kwargs):
         """Return a file wrapper instance.
 
         Raises :class:`~django_downloadview.exceptions.FileNotFound` if file
@@ -151,7 +151,7 @@ class DownloadMixin(object):
 
         """
         try:
-            self.file_instance = self.get_file()
+            self.file_instance = self.get_file(*response_args, **response_kwargs)
         except exceptions.FileNotFound:
             return self.file_not_found_response()
         # Respect the If-Modified-Since header.
@@ -165,6 +165,7 @@ class DownloadMixin(object):
 
 class BaseDownloadView(DownloadMixin, View):
     """A base :class:`DownloadMixin` that implements :meth:`get`."""
+
     def get(self, request, *args, **kwargs):
         """Handle GET requests: stream a file."""
-        return self.render_to_response()
+        return self.render_to_response(*args, **kwargs)

--- a/django_downloadview/views/base.py
+++ b/django_downloadview/views/base.py
@@ -122,8 +122,13 @@ class DownloadMixin(object):
                 return was_modified_since(since, modification_time, size)
 
     def not_modified_response(self, *response_args, **response_kwargs):
-        """Return :class:`django.http.HttpResponseNotModified` instance."""
-        return HttpResponseNotModified(*response_args, **response_kwargs)
+        """Return :class:`django.http.HttpResponseNotModified` instance.
+         Only `django.http.HttpResponseBase.__init__()` kwargs will be used."""
+        allowed_kwargs = {}
+        for k in ('content_type', 'status', 'reason', 'charset'):
+            if k in response_kwargs:
+                allowed_kwargs[k] = response_kwargs[k]
+        return HttpResponseNotModified(*response_args, **allowed_kwargs)
 
     def download_response(self, *response_args, **response_kwargs):
         """Return :class:`~django_downloadview.response.DownloadResponse`."""

--- a/tests/views.py
+++ b/tests/views.py
@@ -21,6 +21,7 @@ from django_downloadview import views
 
 class DownloadMixinTestCase(unittest.TestCase):
     """Test suite around :class:`django_downloadview.views.DownloadMixin`."""
+
     def test_get_file(self):
         """DownloadMixin.get_file() raise NotImplementedError.
 
@@ -218,6 +219,7 @@ class DownloadMixinTestCase(unittest.TestCase):
 
 class BaseDownloadViewTestCase(unittest.TestCase):
     "Tests around :class:`django_downloadviews.views.base.BaseDownloadView`."
+
     def test_get(self):
         """BaseDownloadView.get() calls render_to_response()."""
         request = django.test.RequestFactory().get('/dummy-url')
@@ -228,11 +230,12 @@ class BaseDownloadViewTestCase(unittest.TestCase):
             return_value=mock.sentinel.response)
         response = view.get(request, *args, **kwargs)
         self.assertIs(response, mock.sentinel.response)
-        view.render_to_response.assert_called_once_with()
+        view.render_to_response.assert_called_once_with(*args, **kwargs)
 
 
 class PathDownloadViewTestCase(unittest.TestCase):
     "Tests for :class:`django_downloadviews.views.path.PathDownloadView`."
+
     def test_get_file_ok(self):
         "PathDownloadView.get_file() returns ``File`` instance."
         view = setup_view(views.PathDownloadView(path=__file__),
@@ -262,6 +265,7 @@ class PathDownloadViewTestCase(unittest.TestCase):
 
 class ObjectDownloadViewTestCase(unittest.TestCase):
     "Tests for :class:`django_downloadviews.views.object.ObjectDownloadView`."
+
     def test_get_file_ok(self):
         "ObjectDownloadView.get_file() returns ``file`` field by default."
         view = setup_view(views.ObjectDownloadView(), 'fake request')
@@ -296,6 +300,7 @@ class ObjectDownloadViewTestCase(unittest.TestCase):
 class VirtualDownloadViewTestCase(unittest.TestCase):
     """Test suite around
     :py:class:`django_downloadview.views.VirtualDownloadView`."""
+
     def test_was_modified_since_specific(self):
         """VirtualDownloadView.was_modified_since() delegates to file wrapper.
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -223,8 +223,8 @@ class BaseDownloadViewTestCase(unittest.TestCase):
     def test_get(self):
         """BaseDownloadView.get() calls render_to_response()."""
         request = django.test.RequestFactory().get('/dummy-url')
-        args = ['dummy-arg']
-        kwargs = {'dummy': 'kwarg'}
+        args = []
+        kwargs = {'content_type': 'application/pdf'}
         view = setup_view(views.BaseDownloadView(), request, *args, **kwargs)
         view.render_to_response = mock.Mock(
             return_value=mock.sentinel.response)


### PR DESCRIPTION
Resolves #120.
