### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Let's serve a file stored in a file field of some model:
 Resources
 *********
 
-* Documentation: http://django-downloadview.readthedocs.org
+* Documentation: https://django-downloadview.readthedocs.io
 * PyPI page: http://pypi.python.org/pypi/django-downloadview
 * Code repository: https://github.com/benoitbryon/django-downloadview
 * Bugtracker: https://github.com/benoitbryon/django-downloadview/issues

--- a/demo/setup.py
+++ b/demo/setup.py
@@ -15,7 +15,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 VERSION = open(os.path.join(project_root, 'VERSION')).read().strip()
 AUTHOR = u'Benoît Bryon'
 EMAIL = u'benoit@marmelune.net'
-URL = 'https://django-downloadview.readthedocs.org/'
+URL = 'https://django-downloadview.readthedocs.io/'
 CLASSIFIERS = ['Development Status :: 5 - Production/Stable',
                'License :: OSI Approved :: BSD License',
                'Programming Language :: Python :: 2.7',

--- a/docs/optimizations/nginx.txt
+++ b/docs/optimizations/nginx.txt
@@ -136,7 +136,7 @@ Here is what you could have in :file:`/etc/nginx/sites-available/default`:
        # like /optimized-download/myfile.tar.gz
        #
        # See http://wiki.nginx.org/X-accel
-       # and https://django-downloadview.readthedocs.org
+       # and https://django-downloadview.readthedocs.io
        #
        location /proxied-download {
            internal;

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ VERSION = open(os.path.join(here, 'VERSION')).read().strip()
 AUTHOR = u'Benoît Bryon'
 EMAIL = 'benoit@marmelune.net'
 LICENSE = 'BSD'
-URL = 'https://{name}.readthedocs.org/'.format(name=NAME)
+URL = 'https://{name}.readthedocs.io/'.format(name=NAME)
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Framework :: Django',


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.