### PR TITLE
HTTPDownloadView: Accept relative url.

### DIFF
--- a/django_downloadview/files.py
+++ b/django_downloadview/files.py
@@ -216,8 +216,9 @@ class HTTPFile(File):
 
     """
     def __init__(self, request_factory=requests.get, url='', name=u'',
-                 **kwargs):
+                 base_url=None, **kwargs):
         self.request_factory = request_factory
+        self.base_url = base_url
         self.url = url
         if name is None:
             parts = urlparse(url)
@@ -235,8 +236,8 @@ class HTTPFile(File):
         try:
             return self._request
         except AttributeError:
-            self._request = self.request_factory(self.url,
-                                                 **self.request_kwargs)
+            url = self.base_url + self.url if self.base_url else self.url
+            self._request = self.request_factory(url, **self.request_kwargs)
             return self._request
 
     @property

--- a/django_downloadview/views/http.py
+++ b/django_downloadview/views/http.py
@@ -14,6 +14,12 @@ class HTTPDownloadView(BaseDownloadView):
     #: Additional keyword arguments for request handler.
     request_kwargs = {}
 
+    def get(self, request, *args, **kwargs):
+        if self.url.startswith('/'):  # Relative url.
+            self.base_url = '{scheme}://{host}'.format(
+                scheme=self.request.scheme, host=self.request.get_host())
+        return super(HTTPDownloadView, self).get(request, *args, **kwargs)
+
     def get_request_factory(self):
         """Return request factory to perform actual HTTP request.
 
@@ -42,5 +48,6 @@ class HTTPDownloadView(BaseDownloadView):
         """Return wrapper which has an ``url`` attribute."""
         return HTTPFile(request_factory=self.get_request_factory(),
                         name=self.get_basename(),
+                        base_url=getattr(self, 'base_url', None),
                         url=self.get_url(),
                         **self.get_request_kwargs())


### PR DESCRIPTION
I want to use `HTTPDownloadView` to proxy to assets on the same domain.
This doesn't seem to be a conventional choice, but I don't like any of
the other views for my particular use case -- my django-downloadview's
are redirecting solely on the basis of requested url and I don't think
exposing the path or object id to end users would be ideal.

`HTTPDownloadView` passes it's url to the `requests` library, which
expects a fully qualified url. However, `ProxiedDownloadMiddleware`
depends upon that url being the same one in `DOWNLOADVIEW_RULES`. So in
order to use `HTTPDownloadView`, `DOWNLOAD_RULES` must also contain
fully qualified urls. I don't like this option much because I'd have to
modify `DOWNLOAD_RULES` at startup time to account for different
environments (dev, staging, production, etc).

The solution I propose is to construct a fully qualified url to pass to
requests while leaving the `file.url` relative.

It would be nice to add a test for this but it isn't obvious to me where it should go and I wont bother if the proposal is rejected.
