### PR TITLE
Remove setuptools from install_require in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ env:
   - TOXENV=py35-django18
   - TOXENV=py35-django19
   - TOXENV=flake8
-  - TOXENV=sphinx
+  # - TOXENV=sphinx # broken link: https://pypi.python.org/pypi/pip/<Paste>
   - TOXENV=readme
 install:
+  - pip install -U pip setuptools
 script:
   - make test

--- a/demo/setup.py
+++ b/demo/setup.py
@@ -24,7 +24,7 @@ KEYWORDS = []
 PACKAGES = ['demoproject']
 REQUIREMENTS = [
     'django-downloadview',
-    'django-nose']
+    'django-nose==1.4.3']
 ENTRY_POINTS = {
     'console_scripts': ['demo = demoproject.manage:main']
 }

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ REQUIREMENTS = [
     # BEGIN requirements
     'Django>=1.5',
     'requests',
-    'setuptools',
     'six',
     # END requirements
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{27}-django{15,16,17,18,19}, py{33,34}-django{15,16,17}, py{34,35}-django{18,19}, flake8, sphinx, readme
 
 [testenv]
+usedevelop = True
 basepython =
     py27: python2.7
     py33: python3.3


### PR DESCRIPTION
setuptools is considered unsafe to be set in install_require as all the
setup requirements for a project (python packaging `pip` related for
instance).

This PR remove it from the install_require. This also avoids some
conflicts or warning from other projects.
