### PR TITLE
Add support for Django MIDDLEWARE setting

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -89,6 +89,6 @@ documentation. Maintain it along with code and documentation.
 .. _`rebase`: http://git-scm.com/book/en/Git-Branching-Rebasing
 .. _`merge-based rebase`: http://tech.novapost.fr/psycho-rebasing-en.html
 .. _`pip`: https://pypi.python.org/pypi/pip/
-.. _`tox`: http://tox.testrun.org
+.. _`tox`: https://tox.readthedocs.io
 .. _`Sphinx`: https://pypi.python.org/pypi/Sphinx/
 .. _`zest.releaser`: https://pypi.python.org/pypi/zest.releaser/

--- a/demo/demoproject/settings.py
+++ b/demo/demoproject/settings.py
@@ -64,24 +64,16 @@ INSTALLED_APPS = (
 
 
 # BEGIN middlewares
+MIDDLEWARE_CLASSES = [
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django_downloadview.SmartDownloadMiddleware'
+]
 if StrictVersion(get_version()) >= StrictVersion('1.10'):
-    MIDDLEWARE = [
-        'django.middleware.common.CommonMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django_downloadview.SmartDownloadMiddleware'
-    ]
-else:
-    MIDDLEWARE_CLASSES = [
-        'django.middleware.common.CommonMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django_downloadview.SmartDownloadMiddleware'
-    ]
+    MIDDLEWARE = MIDDLEWARE_CLASSES
 # END middlewares
 
 

--- a/demo/demoproject/settings.py
+++ b/demo/demoproject/settings.py
@@ -64,14 +64,24 @@ INSTALLED_APPS = (
 
 
 # BEGIN middlewares
-MIDDLEWARE_CLASSES = [
-    'django.middleware.common.CommonMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django_downloadview.SmartDownloadMiddleware'
-]
+if StrictVersion(get_version()) >= StrictVersion('1.10'):
+    MIDDLEWARE = [
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django_downloadview.SmartDownloadMiddleware'
+    ]
+else:
+    MIDDLEWARE_CLASSES = [
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django_downloadview.SmartDownloadMiddleware'
+    ]
 # END middlewares
 
 

--- a/demo/demoproject/urlpatterns.py
+++ b/demo/demoproject/urlpatterns.py
@@ -1,5 +1,5 @@
 try:
     from django.conf.urls import patterns
-except:
+except ImportError:
     def patterns(prefix, *args):
         return list(args)

--- a/django_downloadview/apache/middlewares.py
+++ b/django_downloadview/apache/middlewares.py
@@ -12,9 +12,11 @@ class XSendfileMiddleware(ProxiedDownloadMiddleware):
     :py:class:`django_downloadview.decorators.DownloadDecorator`.
 
     """
-    def __init__(self, source_dir=None, source_url=None, destination_dir=None):
+    def __init__(self, get_response=None, source_dir=None, source_url=None,
+                 destination_dir=None):
         """Constructor."""
-        super(XSendfileMiddleware, self).__init__(source_dir,
+        super(XSendfileMiddleware, self).__init__(get_response,
+                                                  source_dir,
                                                   source_url,
                                                   destination_dir)
 

--- a/django_downloadview/io.py
+++ b/django_downloadview/io.py
@@ -40,38 +40,38 @@ class TextIteratorIO(io.TextIOBase):
 
     def read(self, n=None):
         """Return content up to ``n`` length."""
-        l = []
+        parts = []
         if n is None or n < 0:
             while True:
                 m = self._read1()
                 if not m:
                     break
-                l.append(m)
+                parts.append(m)
         else:
             while n > 0:
                 m = self._read1(n)
                 if not m:
                     break
                 n -= len(m)
-                l.append(m)
-        return u''.join(l)
+                parts.append(m)
+        return u''.join(parts)
 
     def readline(self):
-        l = []
+        parts = []
         while True:
             i = self._left.find(u'\n')
             if i == -1:
-                l.append(self._left)
+                parts.append(self._left)
                 try:
                     self._left = next(self._iter)
                 except StopIteration:
                     self._left = u''
                     break
             else:
-                l.append(self._left[:i + 1])
+                parts.append(self._left[:i + 1])
                 self._left = self._left[i + 1:]
                 break
-        return u''.join(l)
+        return u''.join(parts)
 
 
 class BytesIteratorIO(io.BytesIO):
@@ -108,35 +108,35 @@ class BytesIteratorIO(io.BytesIO):
 
     def read(self, n=None):
         """Return content up to ``n`` length."""
-        l = []
+        parts = []
         if n is None or n < 0:
             while True:
                 m = self._read1()
                 if not m:
                     break
-                l.append(m)
+                parts.append(m)
         else:
             while n > 0:
                 m = self._read1(n)
                 if not m:
                     break
                 n -= len(m)
-                l.append(m)
-        return b''.join(l)
+                parts.append(m)
+        return b''.join(parts)
 
     def readline(self):
-        l = []
+        parts = []
         while True:
             i = self._left.find(b'\n')
             if i == -1:
-                l.append(self._left)
+                parts.append(self._left)
                 try:
                     self._left = next(self._iter)
                 except StopIteration:
                     self._left = b''
                     break
             else:
-                l.append(self._left[:i + 1])
+                parts.append(self._left[:i + 1])
                 self._left = self._left[i + 1:]
                 break
-        return b''.join(l)
+        return b''.join(parts)

--- a/django_downloadview/lighttpd/middlewares.py
+++ b/django_downloadview/lighttpd/middlewares.py
@@ -12,9 +12,11 @@ class XSendfileMiddleware(ProxiedDownloadMiddleware):
     :py:class:`django_downloadview.decorators.DownloadDecorator`.
 
     """
-    def __init__(self, source_dir=None, source_url=None, destination_dir=None):
+    def __init__(self, get_response=None, source_dir=None, source_url=None,
+                 destination_dir=None):
         """Constructor."""
-        super(XSendfileMiddleware, self).__init__(source_dir,
+        super(XSendfileMiddleware, self).__init__(get_response,
+                                                  source_dir,
                                                   source_url,
                                                   destination_dir)
 

--- a/django_downloadview/middlewares.py
+++ b/django_downloadview/middlewares.py
@@ -11,6 +11,12 @@ import os
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    class MiddlewareMixin(object):
+        def __init__(self, get_response=None):
+            super(MiddlewareMixin, self).__init__()
 
 from django_downloadview.response import DownloadResponse
 from django_downloadview.utils import import_member
@@ -31,7 +37,7 @@ def is_download_response(response):
     return isinstance(response, DownloadResponse)
 
 
-class BaseDownloadMiddleware(object):
+class BaseDownloadMiddleware(MiddlewareMixin):
     """Base (abstract) Django middleware that handles download responses.
 
     Subclasses **must** implement :py:meth:`process_download_response` method.
@@ -80,7 +86,8 @@ class RealDownloadMiddleware(BaseDownloadMiddleware):
 
 class DownloadDispatcherMiddleware(BaseDownloadMiddleware):
     "Download middleware that dispatches job to several middleware instances."
-    def __init__(self, middlewares=AUTO_CONFIGURE):
+    def __init__(self, get_response=None, middlewares=AUTO_CONFIGURE):
+        super(DownloadDispatcherMiddleware, self).__init__(get_response)
         #: List of children middlewares.
         self.middlewares = middlewares
         if self.middlewares is AUTO_CONFIGURE:
@@ -106,8 +113,10 @@ class DownloadDispatcherMiddleware(BaseDownloadMiddleware):
 class SmartDownloadMiddleware(BaseDownloadMiddleware):
     """Easy to configure download middleware."""
     def __init__(self,
+                 get_response=None,
                  backend_factory=AUTO_CONFIGURE,
                  backend_options=AUTO_CONFIGURE):
+        super(SmartDownloadMiddleware, self).__init__(get_response)
         """Constructor."""
         #: :class:`DownloadDispatcher` instance that can hold multiple
         #: backend instances.
@@ -165,8 +174,10 @@ class NoRedirectionMatch(Exception):
 
 class ProxiedDownloadMiddleware(RealDownloadMiddleware):
     """Base class for middlewares that use optimizations of reverse proxies."""
-    def __init__(self, source_dir=None, source_url=None, destination_url=None):
+    def __init__(self, get_response=None, source_dir=None, source_url=None,
+                 destination_url=None):
         """Constructor."""
+        super(ProxiedDownloadMiddleware, self).__init__(get_response)
         self.source_dir = source_dir
         self.source_url = source_url
         self.destination_url = destination_url

--- a/django_downloadview/nginx/middlewares.py
+++ b/django_downloadview/nginx/middlewares.py
@@ -17,9 +17,9 @@ class XAccelRedirectMiddleware(ProxiedDownloadMiddleware):
     :py:class:`django_downloadview.decorators.DownloadDecorator`.
 
     """
-    def __init__(self, source_dir=None, source_url=None, destination_url=None,
-                 expires=None, with_buffering=None, limit_rate=None,
-                 media_root=None, media_url=None):
+    def __init__(self, get_response=None, source_dir=None, source_url=None,
+                 destination_url=None, expires=None, with_buffering=None,
+                 limit_rate=None, media_root=None, media_url=None):
         """Constructor."""
         if media_url is not None:
             warnings.warn("%s ``media_url`` is deprecated. Use "
@@ -42,7 +42,8 @@ class XAccelRedirectMiddleware(ProxiedDownloadMiddleware):
                 source_dir = source_dir
         else:
             source_dir = source_dir
-        super(XAccelRedirectMiddleware, self).__init__(source_dir,
+        super(XAccelRedirectMiddleware, self).__init__(get_response,
+                                                       source_dir,
                                                        source_url,
                                                        destination_url)
         self.expires = expires
@@ -105,13 +106,14 @@ class SingleXAccelRedirectMiddleware(XAccelRedirectMiddleware):
          Replaced by ``NGINX_DOWNLOAD_MIDDLEWARE_DESTINATION_URL``.
 
     """
-    def __init__(self):
+    def __init__(self, get_response=None):
         """Use Django settings as configuration."""
         if settings.NGINX_DOWNLOAD_MIDDLEWARE_DESTINATION_URL is None:
             raise ImproperlyConfigured(
                 'settings.NGINX_DOWNLOAD_MIDDLEWARE_DESTINATION_URL is '
                 'required by %s middleware' % self.__class__.__name__)
         super(SingleXAccelRedirectMiddleware, self).__init__(
+            get_response=get_response,
             source_dir=settings.NGINX_DOWNLOAD_MIDDLEWARE_SOURCE_DIR,
             source_url=settings.NGINX_DOWNLOAD_MIDDLEWARE_SOURCE_URL,
             destination_url=settings.NGINX_DOWNLOAD_MIDDLEWARE_DESTINATION_URL,


### PR DESCRIPTION
Since Django 1.10 middlewares are configured as `MIDDLEWARE`.

More details:
https://docs.djangoproject.com/en/1.11/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-MIDDLEWARE

This PR adds support to configure `django-downloadivew` middlewares as `MIDDLEWARE`. Backwards compatibility with `MIDDLEWARE_CLASSES` remains.

This fixes #136  For CI to run I included some minor linting fixes.